### PR TITLE
DISCOVER-1970: introducing custom property for app access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "atlassian-openapi",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1764,8 +1764,7 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
@@ -1787,8 +1786,7 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -1930,7 +1928,6 @@
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2109,8 +2106,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2200,8 +2196,7 @@
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atlassian-openapi",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "This is a package that lets you deal with the Atlassian flavour of the OpenAPI 3.0 specification.",
   "repository": "github:robertmassaioli/atlassian-openapi",
   "keywords": [

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -244,6 +244,14 @@ export namespace Swagger {
   export type OAuth2ScopesState = 'Current' | 'Deprecated' | 'Beta';
 
   /**
+   * Data Security Policy for App Access
+   * @see https://hello.atlassian.net/wiki/spaces/ECOTRUST/pages/3047963369/DACI+-+Swagger+OpenAPI+custom+property+for+app+access
+   */
+  export interface DataSecurityPolicy {
+    'app-access-rule-exempt': boolean;
+  }
+
+  /**
    * This interface was referenced by `SwaggerV3`'s JSON-Schema
    * via the `definition` "Operation".
    */
@@ -271,6 +279,7 @@ export namespace Swagger {
     'x-experimental'?: boolean;
     'x-atlassian-connect-scope'?: string;
     'x-atlassian-oauth2-scopes'?: OAuth2Scopes[] | OAuth2ScopesWithState[];
+    'x-atlassian-data-security-policy'?: DataSecurityPolicy[];
   }
   /**
    * This interface was referenced by `SwaggerV3`'s JSON-Schema


### PR DESCRIPTION
To create a top-level grouping property for all data security policy-related settings for APIs and nest the app access rule API within it.

Example:
```/wiki/rest/api/content/{id}/notification/created:
    get:
      tags:
        - Content watches
      summary: Get watches for space
      description: |-
        ...
      operationId: getWatchesForSpace
      parameters:
        ...
      responses:
        ...
      security:
        ...
      x-atlassian-oauth2-scopes:
        ...
      x-atlassian-data-security-policy:
        - app-access-rule-exempt: true